### PR TITLE
Define three procedures for format ~F

### DIFF
--- a/srfi-48.html
+++ b/srfi-48.html
@@ -388,6 +388,15 @@ OPTION	[MNEMONIC]	DESCRIPTION	-- This implementation Assumes ASCII Text Encoding
 (define pretty-print   write) ; ugly but permitted
 ;; (require 'srfi-38)  ;; write-with-shared-structure
 
+;; Following three procedures are used by format ~F .
+;; 'inexact-number->string' determines whether output is fixed-point
+;; notation or exponential notation. In the current definition,
+;; the notation depends on the implementation of 'number->string'.
+;; 'exact-number->string' is expected not to output exponential notation.
+;; 'real-number->string' is used when the digits of ~F is not specified.
+(define (inexact-number->string x) (number->string (exact->inexact x)))
+(define (exact-number->string x)   (number->string (inexact->exact x)))
+(define (real-number->string x)    (number->string x))
 
 ;; FORMAT
 (define (format . args)
@@ -450,19 +459,18 @@ OPTION	[MNEMONIC]	DESCRIPTION	-- This implementation Assumes ASCII Text Encoding
                (let* ( (first-part (substring frac-str 0 digits))
                        (last-part  (substring frac-str digits frac-len))
                        (temp-str*
-                        (number->string
-                         (inexact->exact
-                          (round (string->number
-                                  (string-append first-part "." last-part))))))
+                        (exact-number->string
+                         (round (string->number
+                                 (string-append first-part "." last-part)))))
+                       (dot-pos* (string-index temp-str* #\.))
                        (temp-str
-                        (if (< (string-length temp-str*) digits)
-                            (string-append (make-string
-                                            (- digits (string-length temp-str*))
-                                            #\0)
-                                           temp-str*)
-                            temp-str*))
-                       (dot-pos  (or (string-index  temp-str #\.)
-                                     (string-length temp-str)))
+                        (string-grow
+                         (if dot-pos*
+                             (substring temp-str* 0 dot-pos*)
+                             temp-str*)
+                         digits
+                         #\0))
+                       (dot-pos  (string-length temp-str))
                        (carry?
                         (and (> dot-pos digits)
                              (> (round (string->number
@@ -473,12 +481,11 @@ OPTION	[MNEMONIC]	DESCRIPTION	-- This implementation Assumes ASCII Text Encoding
                             (substring temp-str (- dot-pos digits) dot-pos)
                             (substring temp-str 0 digits)))
                      )
-                 (let ( (pre-str* (if (string=? pre-str "") "0" pre-str))
-                      )
+                 (let ( (pre-str* (if (string=? pre-str "") "0" pre-str)) )
                    (string-append
                     (if carry?
                         (let ( (n (string->number pre-str*)) )
-                          (number->string (if (< n 0) (- n 1) (+ n 1))))
+                          (exact-number->string (if (< n 0) (- n 1) (+ n 1))))
                         pre-str*)
                     "."
                     new-frac
@@ -505,7 +512,7 @@ OPTION	[MNEMONIC]	DESCRIPTION	-- This implementation Assumes ASCII Text Encoding
                   #\space)
                  )
                 (digits
-                 (let* ( (num-str   (number->string (exact->inexact real)))
+                 (let* ( (num-str   (inexact-number->string real))
                          (dot-index (string-index  num-str #\.))
                          (exp-index (string-index  num-str #\e))
                          (length    (string-length num-str))
@@ -542,7 +549,7 @@ OPTION	[MNEMONIC]	DESCRIPTION	-- This implementation Assumes ASCII Text Encoding
                     #\space)
                  ))
                 (else ;; no digits
-                 (string-grow (number->string real) width #\space)))
+                 (string-grow (real-number->string real) width #\space)))
              ))
             (else
              (error
@@ -718,7 +725,7 @@ OPTION  [MNEMONIC]      DESCRIPTION     -- Implementation Assumes ASCII Text Enc
                                          (cons next-char d-digits)
                                          in-width?))
                                )
-                              ((or (char=? next-char #\F) (char=? next-char #\f))
+                              ((char=? (char-upcase next-char) #\F)
                                (let ( (width  (string->number (list->string (reverse w-digits))))
                                       (digits (if (zero? (length d-digits))
                                                   #f


### PR DESCRIPTION
I found that the behavior of format ~F is determined by the implementation
of 'number->string'.

If (number->string (exact->inexact 0.0003)) returns "0.0003",
(format "~1,2F" 0.0003) returns "0.00".

If (number->string (exact->inexact 0.0003)) returns "3.0e-4",
(format "~1,2F" 0.0003) returns "3.00e-4".

I think this behavior should be customizable but it seems difficult.

So, I defined three procedures near the top of code and added a comment
that explains them.

If system provides a kind of 'number->string' that can select whether
output is fixed-point notation or exponential notation, user can use it
by overwriting these procedures.

Also, I refactored some code and confirmed all tests are passed in the
following environment.

OS: Windows 8.1 (64bit)
DevTool: MSYS2/MinGW-w64 (64bit) (gcc version 7.1.0 (Rev2, Built by MSYS2 project))
Scheme: Gauche v0.9.6_pre4, Sagittarius v0.8.4, Racket v6.7
