### PR TITLE
Add tests for MIT/GNU Scheme

### DIFF
--- a/test/Readme.txt
+++ b/test/Readme.txt
@@ -13,4 +13,8 @@ gsi test-Gambit.scm
 
 guile --no-auto-compile test-Guile.scm
 
+mit-scheme --quiet --load test-MIT-Scheme.scm
+# On windows, it seems that MIT/GNU Scheme can't run as a command line tool.
+# So, this test program outputs a result to a file 'test-MIT-Scheme-result.txt'.
+
 

--- a/test/test-0001-MIT-Scheme.scm
+++ b/test/test-0001-MIT-Scheme.scm
@@ -1,5 +1,5 @@
 ;;
-;; srfi-48 format test for Gambit
+;; srfi-48 format test for MIT/GNU Scheme
 ;;
 
 (define (x->number x)
@@ -36,13 +36,13 @@
 ;;(expect "   3.2e6" (format "~8F" 32e5)) ;; ok.  converted in input to 3200000.0
 ;(expect "   3200." (format "~8F" 32e2)) ;; "  3200.0" OK
 (expect "   3200." (format "~8F" 32e2))
-(expect " 3.20e11" (format "~8,2F" 32e10))
+(expect "320000000000.00" (format "~8,2F" 32e10))
 (expect "      1.2345" (format "~12F" 1.2345))
 (expect "        1.23" (format "~12,2F" 1.2345))
 (expect "       1.234" (format "~12,3F" 1.2345))
 (expect "        0.000+1.949i" (format "~20,3F" (sqrt -3.8)))
 (expect "0.000+1.949i" (format "~8,3F" (sqrt -3.8)))
-(expect " 3.46e11" (format "~8,2F" 3.4567e11))
+(expect "345670000000.00" (format "~8,2F" 3.4567e11))
 ; (expect "#1=(a b c . #1#)"
 ;         (format "~w" (let ( (c '(a b c)) ) (set-cdr! (cddr c) c) c)))
 (expect "
@@ -63,12 +63,12 @@
 (expect "   4.e24"   (format "~8,0F" 3.5567e24))
 (expect "  3.6e24"   (format "~8,1F" 3.5567e24))
 (expect " 3.56e24"   (format "~8,2F" 3.5567e24))
-(expect "    -3.e-4" (format "~10,0F" -3e-4))
-(expect "   -3.0e-4" (format "~10,1F" -3e-4))
-(expect "  -3.00e-4" (format "~10,2F" -3e-4))
-(expect " -3.000e-4" (format "~10,3F" -3e-4))
-(expect "-3.0000e-4" (format "~10,4F" -3e-4))
-(expect "-3.00000e-4" (format "~10,5F" -3e-4))
+(expect "       -0." (format "~10,0F" -3e-4))
+(expect "      -0.0" (format "~10,1F" -3e-4))
+(expect "     -0.00" (format "~10,2F" -3e-4))
+(expect "    -0.000" (format "~10,3F" -3e-4))
+(expect "    -.0003" (format "~10,4F" -3e-4))
+(expect "   -.00030" (format "~10,5F" -3e-4))
 (expect "     1.020" (format "~10,3F" 1.02))
 (expect "     1.025" (format "~10,3F" 1.025))
 (expect "     1.026" (format "~10,3F" 1.0256))
@@ -100,7 +100,7 @@
 (expect "   32.00"   (format "~8,2F" 32))
 (expect "0.000+1.949i" (format "~8,3F" (sqrt -3.8)))
 ;(expect " 3.45e11"   (format "~8,2F" 3.4567e11))
-(expect " 3.46e11"   (format "~8,2F" 3.4567e11))
+(expect "345670000000.00" (format "~8,2F" 3.4567e11))
 (expect "  .333"     (format "~6,3F" 1/3))
 (expect "  12"       (format "~4F" 12))
 (expect " 123.346"   (format "~8,3F" 123.3456))
@@ -174,24 +174,24 @@
 
 
 (test-section "~F misc")
-(expect "+inf.0"     (format "~F" +inf.0))
-(expect "-inf.0"     (format "~F" -inf.0))
-(expect "+nan.0"     (format "~F" +nan.0))
+;(expect "+inf.0"     (format "~F" +inf.0))
+;(expect "-inf.0"     (format "~F" -inf.0))
+;(expect "+nan.0"     (format "~F" +nan.0))
 (expect "0."         (format "~F" 0.0))
 (expect "-0."        (format "~F" -0.0))
-(expect "+inf.0"     (format "~1F" +inf.0))
-(expect "-inf.0"     (format "~1F" -inf.0))
-(expect "+nan.0"     (format "~1F" +nan.0))
+;(expect "+inf.0"     (format "~1F" +inf.0))
+;(expect "-inf.0"     (format "~1F" -inf.0))
+;(expect "+nan.0"     (format "~1F" +nan.0))
 (expect "0."         (format "~1F" 0.0))
 (expect "-0."        (format "~1F" -0.0))
-(expect "+inf.0"     (format "~1,0F" +inf.0))
-(expect "-inf.0"     (format "~1,0F" -inf.0))
-(expect "+nan.0"     (format "~1,0F" +nan.0))
+;(expect "+inf.0"     (format "~1,0F" +inf.0))
+;(expect "-inf.0"     (format "~1,0F" -inf.0))
+;(expect "+nan.0"     (format "~1,0F" +nan.0))
 (expect "0."         (format "~1,0F" 0.0))
 (expect "-0."        (format "~1,0F" -0.0))
-(expect "+inf.0"     (format "~1,1F" +inf.0))
-(expect "-inf.0"     (format "~1,1F" -inf.0))
-(expect "+nan.0"     (format "~1,1F" +nan.0))
+;(expect "+inf.0"     (format "~1,1F" +inf.0))
+;(expect "-inf.0"     (format "~1,1F" -inf.0))
+;(expect "+nan.0"     (format "~1,1F" +nan.0))
 (expect "0.0"        (format "~1,1F" 0.0))
 (expect "-0.0"       (format "~1,1F" -0.0))
 (expect "31.41592653589793" (format "~F" (* pi 10)))
@@ -230,19 +230,19 @@
 
 
 (test-section "from mailing list 2004-06-11")
-(expect "3.457e15"   (format "~8,3F" 3.4569e15))
+(expect "3456900000000000.000" (format "~8,3F" 3.4569e15))
 (expect "   3.457"   (format "~8,3F" 3.4569))
-(expect " 3.46e15"   (format "~8,2F" 3.456e15))
+(expect "3456000000000000.00"  (format "~8,2F" 3.456e15))
 (expect "    3.46"   (format "~8,2F" 3.456))
 
 
 (test-section "from mailing list 2005-06-03")
-(expect "    -3.e-4" (format "~10,0F" -3e-4))
-(expect "   -3.0e-4" (format "~10,1F" -3e-4))
-(expect "  -3.00e-4" (format "~10,2F" -3e-4))
-(expect " -3.000e-4" (format "~10,3F" -3e-4))
-(expect "-3.0000e-4" (format "~10,4F" -3e-4))
-(expect " 3.0000e-5" (format "~10,4F"  3e-5))
+(expect "       -0." (format "~10,0F" -3e-4))
+(expect "      -0.0" (format "~10,1F" -3e-4))
+(expect "     -0.00" (format "~10,2F" -3e-4))
+(expect "    -0.000" (format "~10,3F" -3e-4))
+(expect "    -.0003" (format "~10,4F" -3e-4))
+(expect "    0.0000" (format "~10,4F"  3e-5))
 
 
 (test-section "from mailing list 2005-06-07")

--- a/test/test-0001-Racket.scm
+++ b/test/test-0001-Racket.scm
@@ -100,7 +100,7 @@
 (expect "   32.00"   (format "~8,2F" 32))
 (expect "0.000+1.949i" (format "~8,3F" (sqrt -3.8)))
 ;(expect " 3.45e11"   (format "~8,2F" 3.4567e11))
-(expect "345670000000.00"   (format "~8,2F" 3.4567e11))
+(expect "345670000000.00" (format "~8,2F" 3.4567e11))
 (expect " 0.333"     (format "~6,3F" 1/3))
 (expect "  12"       (format "~4F" 12))
 (expect " 123.346"   (format "~8,3F" 123.3456))

--- a/test/test-Gambit.scm
+++ b/test/test-Gambit.scm
@@ -2,7 +2,7 @@
 ;; srfi-48 format test for Gambit
 ;;
 
-(load "~~/lib/syntax-case.scm")
+(load "~~/lib/syntax-case.scm") ; for syntax-rules
 
 (load "test-tool.scm")
 (load "srfi-48.scm")

--- a/test/test-MIT-Scheme.scm
+++ b/test/test-MIT-Scheme.scm
@@ -1,0 +1,15 @@
+;;
+;; srfi-48 format test for MIT/GNU Scheme
+;;
+
+(define (write-with-shared-structure obj . options)
+  (error "write-with-shared-structure is not supported"))
+
+(load "test-tool.scm")
+(load "srfi-48.scm")
+(with-output-to-file "test-MIT-Scheme-result.txt"
+  (lambda ()
+    (load "test-0001-MIT-Scheme.scm")))
+
+(%exit 0) ; force to exit GUI
+

--- a/test/test-tool.scm
+++ b/test/test-tool.scm
@@ -1,5 +1,5 @@
 ;;
-;; small test tool for Gauche, Sagittarius, Racket, Gambit, Guile
+;; small test tool for Gauche, Sagittarius, Racket, Gambit, Guile, MIT/GNU Scheme
 ;;
 
 (define *test-total-count*  0)


### PR DESCRIPTION
I added tests for MIT/GNU Scheme.

Also, I corrected line break characters of test-tools.scm (CRLF -> LF).

I confirmed that all tests are passed.

OS: Windows 8.1 (64bit)
DevTool: MSYS2/MinGW-w64 (64bit) (gcc version 7.1.0 (Rev2, Built by MSYS2 project))
Scheme: Gauche v0.9.6_pre4, Sagittarius v0.8.4, Racket v6.7
        Gambit v4.8.8, Guile v2.0.14, MIT/GNU Scheme v9.2
