### PR TITLE
Add tests for Chez Scheme and Chicken Scheme

### DIFF
--- a/test/Readme.txt
+++ b/test/Readme.txt
@@ -17,4 +17,8 @@ mit-scheme --quiet --load test-MIT-Scheme.scm
 # On windows, it seems that MIT/GNU Scheme can't run as a command line tool.
 # So, this test program outputs a result to a file 'test-MIT-Scheme-result.txt'.
 
+scheme --quiet test-ChezScheme.scm
+
+csi -quiet test-Chicken.scm
+
 

--- a/test/test-0001-Chicken.scm
+++ b/test/test-0001-Chicken.scm
@@ -1,5 +1,5 @@
 ;;
-;; srfi-48 format test for Racket
+;; srfi-48 format test for Chicken
 ;;
 
 (define (x->number x)
@@ -26,7 +26,7 @@
 (expect "  12.346" (format "~8,3F" 12.3456))
 (expect "123.346" (format "~6,3F" 123.3456))
 (expect "123.346" (format "~4,3F" 123.3456))
-(expect "0.000+1.949i" (format "~8,3F" (sqrt -3.8)))
+;(expect "0.000+1.949i" (format "~8,3F" (sqrt -3.8)))
 (expect " 32.00" (format "~6,2F" 32))
 (expect "    32" (format "~6F" 32))
 ;(expect "   32." (format "~6F" 32.)) ;; "  32.0" OK
@@ -42,8 +42,8 @@
 (expect "      1.2345" (format "~12F" 1.2345))
 (expect "        1.23" (format "~12,2F" 1.2345))
 (expect "       1.234" (format "~12,3F" 1.2345))
-(expect "        0.000+1.949i" (format "~20,3F" (sqrt -3.8)))
-(expect "0.000+1.949i" (format "~8,3F" (sqrt -3.8)))
+;(expect "        0.000+1.949i" (format "~20,3F" (sqrt -3.8)))
+;(expect "0.000+1.949i" (format "~8,3F" (sqrt -3.8)))
 (expect "345670000000.00" (format "~8,2F" 3.4567e11))
 ; (expect "#1=(a b c . #1#)"
 ;         (format "~w" (let ( (c '(a b c)) ) (set-cdr! (cddr c) c) c)))
@@ -84,7 +84,7 @@
 (expect "    32"     (format "~6F" 32))
 (expect "   32.00"   (format "~8,2F" 32))
 (expect "4321.00"    (format "~1,2F" 4321))
-(expect "0.00+1.97i" (format "~1,2F" (sqrt -3.9)))
+;(expect "0.00+1.97i" (format "~1,2F" (sqrt -3.9)))
 (expect "3200000.0"  (format "~8F" 32e5))
 ;(expect "   3.2e6"   (format "~8F" 32e5))
 (expect "<string>"   (format "~h") (lambda (e r) (string? r)))
@@ -100,7 +100,7 @@
 ;(expect "#1=(a b c . #1#)" (format "~w" (let ( (c '(a b c)) ) (set-cdr! (cddr c) c) c)))
 ;(expect "#0=(a b c . #0#)" (format "~w" (let ( (c (list 'a 'b 'c)) ) (set-cdr! (cddr c) c) c)))
 (expect "   32.00"   (format "~8,2F" 32))
-(expect "0.000+1.949i" (format "~8,3F" (sqrt -3.8)))
+;(expect "0.000+1.949i" (format "~8,3F" (sqrt -3.8)))
 ;(expect " 3.45e11"   (format "~8,2F" 3.4567e11))
 (expect "345670000000.00" (format "~8,2F" 3.4567e11))
 (expect " 0.333"     (format "~6,3F" 1/3))
@@ -196,7 +196,7 @@
 (expect "+nan.0"     (format "~1,1F" +nan.0))
 (expect "0.0"        (format "~1,1F" 0.0))
 (expect "-0.0"       (format "~1,1F" -0.0))
-(expect "31.41592653589793" (format "~F" (* pi 10)))
+(expect "31.4159265358979" (format "~F" (* pi 10)))
 (expect "0.33333"    (format "~1,5F"  1/3))
 (expect "-0.33333"   (format "~1,5F" -1/3))
 (expect "0.142857142857" (format "~1,12F"  1/7))

--- a/test/test-0001-Gambit.scm
+++ b/test/test-0001-Gambit.scm
@@ -9,9 +9,11 @@
    (else (error "x->number error"))))
 
 (define (nearly=? a b)
-  (let ((a1 (x->number a)) (b1 (x->number b)))
-    ;(format #t "(result = ~s, num-e = ~s, num-r = ~s)\n" b a1 b1)
-    (< (abs (- a1 b1)) 1.0e-10)))
+  (let* ((a1 (x->number a))
+         (b1 (x->number b))
+         (e1 (abs (- a1 b1))))
+    ;(format #t "(a1 = ~s, b1 = ~s, e1 = ~s)~%" a1 b1 e1)
+    (< e1 1.0e-10)))
 
 (define pi 3.141592653589793)
 

--- a/test/test-0001-MIT-Scheme.scm
+++ b/test/test-0001-MIT-Scheme.scm
@@ -9,9 +9,11 @@
    (else (error "x->number error"))))
 
 (define (nearly=? a b)
-  (let ((a1 (x->number a)) (b1 (x->number b)))
-    ;(format #t "(result = ~s, num-e = ~s, num-r = ~s)\n" b a1 b1)
-    (< (abs (- a1 b1)) 1.0e-10)))
+  (let* ((a1 (x->number a))
+         (b1 (x->number b))
+         (e1 (abs (- a1 b1))))
+    ;(format #t "(a1 = ~s, b1 = ~s, e1 = ~s)~%" a1 b1 e1)
+    (< e1 1.0e-10)))
 
 (define pi 3.141592653589793)
 

--- a/test/test-0001.scm
+++ b/test/test-0001.scm
@@ -1,5 +1,5 @@
 ;;
-;; srfi-48 format test for Gauche, Sagittarius, Guile
+;; srfi-48 format test for Gauche, Sagittarius, Guile, Chez Scheme
 ;;
 
 (cond-expand
@@ -13,9 +13,11 @@
   ))
 
 (define (nearly=? a b)
-  (let ((a1 (x->number a)) (b1 (x->number b)))
-    ;(format #t "(result = ~s, num-e = ~s, num-r = ~s)\n" b a1 b1)
-    (< (abs (- a1 b1)) 1.0e-10)))
+  (let* ((a1 (x->number a))
+         (b1 (x->number b))
+         (e1 (abs (- a1 b1))))
+    ;(format #t "(a1 = ~s, b1 = ~s, e1 = ~s)~%" a1 b1 e1)
+    (< e1 1.0e-10)))
 
 (define pi 3.141592653589793)
 
@@ -100,8 +102,14 @@
 (expect "3  2 2  3 \n" (format #f "~a ~? ~a ~%" 3 " ~s ~s " '(2 2) 3))
 ;; incorrect mutation of literal list in example
 ;(expect "#1=(a b c . #1#)" (format "~w" (let ( (c '(a b c)) ) (set-cdr! (cddr c) c) c)))
-(expect "#0=(a b c . #0#)" (format "~w" (let ( (c (list 'a 'b 'c)) ) (set-cdr! (cddr c) c) c))
-        (lambda (e r) (or (equal? e r) (equal? "#1=(a b c . #1#)" r))))
+(cond-expand
+ (chezscheme)
+ (guile
+  (expect "#1=(a b c . #1#)" (format "~w" (let ( (c (list 'a 'b 'c)) ) (set-cdr! (cddr c) c) c)))
+  )
+ (else
+  (expect "#0=(a b c . #0#)" (format "~w" (let ( (c (list 'a 'b 'c)) ) (set-cdr! (cddr c) c) c)))
+  ))
 (expect "   32.00"   (format "~8,2F" 32))
 (expect "0.000+1.949i" (format "~8,3F" (sqrt -3.8)))
 ;(expect " 3.45e11"   (format "~8,2F" 3.4567e11))

--- a/test/test-ChezScheme.scm
+++ b/test/test-ChezScheme.scm
@@ -1,0 +1,57 @@
+;;
+;; srfi-48 format test for Chez Scheme
+;;
+
+(import (rnrs))
+
+;; srfi-0
+(define-syntax cond-expand
+  (syntax-rules (and or not else srfi-0 chezscheme)
+    ((cond-expand) (syntax-error "Unfulfilled cond-expand"))
+    ((cond-expand (else body ...))
+     (begin body ...))
+    ((cond-expand ((and) body ...) more-clauses ...)
+     (begin body ...))
+    ((cond-expand ((and req1 req2 ...) body ...) more-clauses ...)
+     (cond-expand
+      (req1
+       (cond-expand
+        ((and req2 ...) body ...)
+        more-clauses ...))
+      more-clauses ...))
+    ((cond-expand ((or) body ...) more-clauses ...)
+     (cond-expand more-clauses ...))
+    ((cond-expand ((or req1 req2 ...) body ...) more-clauses ...)
+     (cond-expand
+      (req1
+       (begin body ...))
+      (else
+       (cond-expand
+        ((or req2 ...) body ...)
+        more-clauses ...))))
+    ((cond-expand ((not req) body ...) more-clauses ...)
+     (cond-expand
+      (req
+       (cond-expand more-clauses ...))
+      (else body ...)))
+    ((cond-expand (srfi-0 body ...) more-clauses ...)
+     (begin body ...))
+    ((cond-expand (chezscheme body ...) more-clauses ...)
+     (begin body ...))
+    ((cond-expand (feature-id body ...) more-clauses ...)
+     (cond-expand more-clauses ...))))
+
+;; Chez's 'error' needs a first argument 'who'.
+(define error-orig error)
+(define (error . args)
+  (apply error-orig 'test args))
+
+(define (write-with-shared-structure obj . options)
+  (error "write-with-shared-structure is not supported"))
+
+(include "test-tool.scm")
+(include "srfi-48.scm")
+(include "test-0001.scm")
+
+(exit)
+

--- a/test/test-Chicken.scm
+++ b/test/test-Chicken.scm
@@ -1,0 +1,13 @@
+;;
+;; srfi-48 format test for Chicken
+;;
+
+(define (write-with-shared-structure obj . options)
+  (error "write-with-shared-structure is not supported"))
+
+(include "test-tool.scm")
+(include "srfi-48.scm")
+(include "test-0001-Chicken.scm")
+
+(exit)
+

--- a/test/test-tool.scm
+++ b/test/test-tool.scm
@@ -1,5 +1,5 @@
 ;;
-;; small test tool for Gauche, Sagittarius, Racket, Gambit, Guile, MIT/GNU Scheme
+;; small test tool for Scheme
 ;;
 
 (define *test-total-count*  0)


### PR DESCRIPTION
I added tests for Chez Scheme and Chicken Scheme.

I confirmed that all tests are passed.

I will finish adding tests.

I learned many things about Scheme in this one week.

I wish these tests increase the value of this srfi.

Thanks.

OS: Windows 8.1 (64bit)
DevTool: MSYS2/MinGW-w64 (64bit) (gcc version 7.1.0 (Rev2, Built by MSYS2 project))
Scheme: Gauche v0.9.6_pre4, Sagittarius v0.8.4, Racket v6.7,
        Gambit v4.8.8, Guile v2.0.14, MIT/GNU Scheme v9.2,
        Chez Scheme v9.5, Chicken v4.12.0
