### PR TITLE
Fix tests for R6RS's 'error' procedure.

### DIFF
--- a/test/test-ChezScheme.scm
+++ b/test/test-ChezScheme.scm
@@ -41,7 +41,7 @@
     ((cond-expand (feature-id body ...) more-clauses ...)
      (cond-expand more-clauses ...))))
 
-;; Chez's 'error' needs a first argument 'who'.
+;; R6RS's 'error' needs a first argument 'who'.
 (define error-orig error)
 (define (error . args)
   (apply error-orig 'test args))

--- a/test/test-Sagittarius.scm
+++ b/test/test-Sagittarius.scm
@@ -4,6 +4,11 @@
 
 (import (rnrs))
 
+;; R6RS's 'error' needs a first argument 'who'.
+(define error-orig error)
+(define (error . args)
+  (apply error-orig 'test args))
+
 (define write-with-shared-structure write/ss)
 (define exact->inexact inexact)
 (define inexact->exact exact)


### PR DESCRIPTION
Sorry, I noticed that R6RS's 'error' procedure needs a first argument 'who'.

For this, I modified test-ChezScheme.scm and test-Sagittarius.scm.
