### PR TITLE
Fix test for Racket

### DIFF
--- a/test/test-Racket.scm
+++ b/test/test-Racket.scm
@@ -13,9 +13,7 @@
     ((_ test then)
      (when test then))
     ((_ test then else1)
-     (cond (test then) (else else1)))
-    ((_ . other)
-     (syntax-error "malformed if"))))
+     (cond (test then) (else else1)))))
 
 (include "test-tool.scm")
 (include "srfi-48.scm")


### PR DESCRIPTION
Sorry, I noticed that Racket doesn't have 'syntax-error'.
I removed it from test-Racket.scm.
