### PR TITLE
Remove an unnecessary procedure

### DIFF
--- a/srfi-48.html
+++ b/srfi-48.html
@@ -392,7 +392,9 @@ OPTION	[MNEMONIC]	DESCRIPTION	-- This implementation Assumes ASCII Text Encoding
 ;; 'inexact-number->string' determines whether output is fixed-point
 ;; notation or exponential notation. In the current definition,
 ;; the notation depends on the implementation of 'number->string'.
-;; 'exact-number->string' is expected not to output exponential notation.
+;; 'exact-number->string' is expected to output only numeric characters
+;; (not including such as '#', 'e', '.', '/') if the input is an positive
+;; integer or zero.
 ;; 'real-number->string' is used when the digits of ~F is not specified.
 (define (inexact-number->string x) (number->string (exact->inexact x)))
 (define (exact-number->string x)   (number->string (inexact->exact x)))
@@ -442,12 +444,6 @@ OPTION	[MNEMONIC]	DESCRIPTION	-- This implementation Assumes ASCII Text Encoding
                (string-append (make-string off char) str)
                str)))
 
-         (define (string-remove-frac-part str)
-           (let ( (dot-pos (string-index str #\.)) )
-             (if dot-pos
-               (substring str 0 dot-pos)
-               str)))
-
          (define (compose-with-digits digits pre-str frac-str exp-str)
            (let ( (frac-len (string-length frac-str)) )
              (cond
@@ -471,10 +467,9 @@ OPTION	[MNEMONIC]	DESCRIPTION	-- This implementation Assumes ASCII Text Encoding
                        (last-part  (substring frac-str digits frac-len))
                        (temp-str
                         (string-grow
-                         (string-remove-frac-part
-                          (exact-number->string
-                           (round (string->number
-                                   (string-append pre-str* first-part "." last-part)))))
+                         (exact-number->string
+                          (round (string->number
+                                  (string-append pre-str* first-part "." last-part))))
                          digits
                          #\0))
                        (temp-len   (string-length temp-str))

--- a/test/srfi-48.scm
+++ b/test/srfi-48.scm
@@ -12,7 +12,9 @@
 ;; 'inexact-number->string' determines whether output is fixed-point
 ;; notation or exponential notation. In the current definition,
 ;; the notation depends on the implementation of 'number->string'.
-;; 'exact-number->string' is expected not to output exponential notation.
+;; 'exact-number->string' is expected to output only numeric characters
+;; (not including such as '#', 'e', '.', '/') if the input is an positive
+;; integer or zero.
 ;; 'real-number->string' is used when the digits of ~F is not specified.
 (define (inexact-number->string x) (number->string (exact->inexact x)))
 (define (exact-number->string x)   (number->string (inexact->exact x)))
@@ -62,12 +64,6 @@
                (string-append (make-string off char) str)
                str)))
 
-         (define (string-remove-frac-part str)
-           (let ( (dot-pos (string-index str #\.)) )
-             (if dot-pos
-               (substring str 0 dot-pos)
-               str)))
-
          (define (compose-with-digits digits pre-str frac-str exp-str)
            (let ( (frac-len (string-length frac-str)) )
              (cond
@@ -91,10 +87,9 @@
                        (last-part  (substring frac-str digits frac-len))
                        (temp-str
                         (string-grow
-                         (string-remove-frac-part
-                          (exact-number->string
-                           (round (string->number
-                                   (string-append pre-str* first-part "." last-part)))))
+                         (exact-number->string
+                          (round (string->number
+                                  (string-append pre-str* first-part "." last-part))))
                          digits
                          #\0))
                        (temp-len   (string-length temp-str))


### PR DESCRIPTION
I noticed the following description in R7RS.
```
6.2.5. Syntax of numerical constants
...
If the written representation of a number has no exactness prefix,
the constant is inexact if it contains a decimal point or an exponent.
Otherwise, it is exact.
...
```
Similar descriptions exists in R5RS and R6RS.

Thus, I removed an unnecessary procedure 'string-remove-frac-part'
and modified a comment of 'exact-number->string'.

I confirmed that all tests are passed.

OS: Windows 8.1 (64bit)
DevTool: MSYS2/MinGW-w64 (64bit) (gcc version 7.1.0 (Rev2, Built by MSYS2 project))
Scheme: Gauche v0.9.6_pre4, Sagittarius v0.8.4, Racket v6.7,
        Gambit v4.8.8, Guile v2.0.14, MIT/GNU Scheme v9.2,
        Chez Scheme v9.5, Chicken v4.12.0
